### PR TITLE
Fix error: ${EVIDENCE_LOG}: ambiguous redirect

### DIFF
--- a/todo.actions.d/donow
+++ b/todo.actions.d/donow
@@ -44,7 +44,7 @@ elog()
         touch ${EVIDENCE_LOG}
     fi
     if [ -f ${EVIDENCE_LOG} ] ; then
-        echo $(date "+%F %T") "$1" >> ${EVIDENCE_LOG}
+        echo $(date "+%F %T") "$1" >> "${EVIDENCE_LOG}"
     fi
 }
 


### PR DESCRIPTION
Without the quotes I get an error on Mac OS X 10.11.1
