### PR TITLE
Use $TODO_FULL_SH for todo.sh invocations.

### DIFF
--- a/todo.actions.d/add
+++ b/todo.actions.d/add
@@ -26,9 +26,9 @@ elif [ x"$1" = x"x" ]; then
 fi
 
 # call back to the main script to add
-if "$TODO_SH" command add "$@"; then
+if "$TODO_FULL_SH" command add "$@"; then
     # figure out the line of what we just added, and "do" it
     line=`sed -n '$ =' "$TODO_FILE"`
-    [ $PRIORITY != false ] && "$TODO_SH" command pri "$line" $PRIORITY
-    $DO && "$TODO_SH" command do "$line"
+    [ $PRIORITY != false ] && "$TODO_FULL_SH" command pri "$line" $PRIORITY
+    $DO && "$TODO_FULL_SH" command do "$line"
 fi

--- a/todo.actions.d/archive
+++ b/todo.actions.d/archive
@@ -2,6 +2,6 @@
 
 [ "$1" = "usage" ] && exit 0
 
-grep "^x" "$TODO_FILE" | while read -r line; do "$TODO_SH" note __archive $line; done
+grep "^x" "$TODO_FILE" | while read -r line; do "$TODO_FULL_SH" note __archive $line; done
 
-"$TODO_SH" command "$@"
+"$TODO_FULL_SH" command "$@"

--- a/todo.actions.d/del
+++ b/todo.actions.d/del
@@ -9,6 +9,6 @@ if [ -z "$3" ]; then
     getTodo "$item"
 fi
 
-"$TODO_SH" command "$@"
+"$TODO_FULL_SH" command "$@"
 
-[ $? -eq 0 ] && [ -z "$3" ] && "$TODO_SH" note __rmfromtext "DDDD$todo"
+[ $? -eq 0 ] && [ -z "$3" ] && "$TODO_FULL_SH" note __rmfromtext "DDDD$todo"

--- a/todo.actions.d/donow
+++ b/todo.actions.d/donow
@@ -53,14 +53,14 @@ update_activity()
     if [[ ! $WORKED_TIME -eq 0 ]]; then
         echo
         if [[ $curr_time_worked = false ]]; then
-            "$TODO_SH" command append $ITEM "min:$WORKED_TIME"
+            "$TODO_FULL_SH" command append $ITEM "min:$WORKED_TIME"
         else
             let "curr_time_worked = $curr_time_worked + $WORKED_TIME"
             # pruning priority from summary
             no_pri_summary=`echo $summary | sed -E "s_\([A-Z]+\) __g"`
             # updating minutes counter
             new_summary=`echo "$no_pri_summary" | sed -E "s/min:[0-9]+/min:$curr_time_worked/g"`
-            "$TODO_SH" command replace $ITEM "$new_summary"
+            "$TODO_FULL_SH" command replace $ITEM "$new_summary"
         fi
     fi
     elog "stop : ${SUMMARY}"

--- a/todo.actions.d/rm
+++ b/todo.actions.d/rm
@@ -3,4 +3,4 @@
 [ "$1" = "usage" ] && exit 0
 
 shift
-"$TODO_SH" del "$@"
+"$TODO_FULL_SH" del "$@"


### PR DESCRIPTION
According to
https://github.com/ginatrapani/todo.txt-cli/wiki/Creating-and-Installing-Add-ons,
one should use $TODO_FULL_SH (the full path of the todo.sh script) for
invocation, rather than $TODO_SH (just the script name, for error messages).
This ensures the scripts work when the todo.sh script is not in the PATH.